### PR TITLE
Add the support of authenticated connection

### DIFF
--- a/DependencyInjection/BlablacarRedisExtension.php
+++ b/DependencyInjection/BlablacarRedisExtension.php
@@ -46,6 +46,11 @@ class BlablacarRedisExtension extends Extension
             if (isset($clientConfig['base'])) {
                 $baseClientDefinition->replaceArgument(3, $clientConfig['base']);
             }
+
+            if (isset($clientConfig['password'])) {
+                $baseClientDefinition->replaceArgument(4, $clientConfig['password']);
+            }
+
             $baseClientDefinition->addTag('redis.client', array('client_name' => $name));
 
             if (!$enableLogger) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
                                 ->defaultValue(0.0)
                             ->end()
                             ->integerNode('base')->end()
+                            ->scalarNode('password')->defaultValue(null)->end()
                         ->end()
                     ->end()
                 ->end()

--- a/Resources/config/redis.xml
+++ b/Resources/config/redis.xml
@@ -9,10 +9,11 @@
 
     <services>
         <service id="blablacar_redis.client.base" class="%blablacar_redis.client.base.class%">
-            <argument></argument>
-            <argument></argument>
-            <argument>0.0</argument>
-            <argument>null</argument>
+            <argument></argument> <!-- host -->
+            <argument></argument> <!-- port -->
+            <argument>0.0</argument> <!-- timeout -->
+            <argument>null</argument> <!-- base -->
+            <argument>null</argument> <!-- password -->
         </service>
 
         <service id="blablacar_redis.client.logger" class="%blablacar_redis.client.logger.class%">


### PR DESCRIPTION
Since the last update of the redis-client, it is possible to configure the authentication.
This commit add the possibility to configure it via a new parameters "password".
The default value is "null" which means that the connection is not authenticated.